### PR TITLE
chore: Bump SDK and IBC-GO Versions 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
-	github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20
-	github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.21
+	github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21
+	github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.22
 	github.com/reapchain/reapchain-core v0.34.20-reap.core.v0.1.24
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/rs/cors v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -1165,12 +1165,12 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20 h1:kbcLcH5yuecyx2kOJUKA1GKDmyZg9yOhfv1oqd/4RCE=
-github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20/go.mod h1:I3Wo3Cb8nnWZ0JgUctDMcZOPcNHsW5SKITEI3jBBMr4=
+github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21 h1:FV9LxAn8csWyo0zgDCz/NRW872cV8dwlxZjpouI5KPg=
+github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21/go.mod h1:I3Wo3Cb8nnWZ0JgUctDMcZOPcNHsW5SKITEI3jBBMr4=
 github.com/reapchain/iavl v0.19.0-reap.iavl.v0.2.15 h1:55zL7iuUaOi9Y3rk4IP808svdF9IG+iFlPLkdieUesU=
 github.com/reapchain/iavl v0.19.0-reap.iavl.v0.2.15/go.mod h1:MgF055gx3gwcShAoCUzt+um46W88iQ1BZz4GJFXzoXc=
-github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.21 h1:vWr7HSdrsiJwnLx314nGa4e5YvoQcVvfQdXe6qtrEwo=
-github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.21/go.mod h1:82+9e8kUg0qqrt5VYIi4xiW9RIuVbbgLkCMOOzCwVtI=
+github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.22 h1:nPCH5JQ/wwjH7DCr2TxlNpFlObYhryY0qYl8IMEBq7s=
+github.com/reapchain/ibc-go/v3 v3.2.0-reap.ibc.v0.5.22/go.mod h1:k+h96n7ffmkwxy9E44NRbJkqH9HGXlRLsyUwaIpkDZs=
 github.com/reapchain/reapchain-core v0.34.20-reap.core.v0.1.24 h1:L/3DMs5Q4qs0xkeovmZhZ86I1fjAgtct0C84MotjJfI=
 github.com/reapchain/reapchain-core v0.34.20-reap.core.v0.1.24/go.mod h1:JvYq9sN5x1x6Uf3xG26pO/4xYRco0Wmdo5RJxUtgjSM=
 github.com/regen-network/cosmos-proto v0.3.1 h1:rV7iM4SSFAagvy8RiyhiACbWEGotmqzywPxOvwMdxcg=


### PR DESCRIPTION
# Pull Request: Bump SDK and IBC-GO Versions

## Description
This pull request proposes bumping the SDK and IBC-GO versions to `0.45.7-reap.sdk.v0.4.21` and `3.2.0-reap.ibc.v0.5.22` respectively. The update involves updating both SDK and IBC-GO dependencies to the specified versions.

## Changes Made
- Updated SDK dependency to version `0.45.7-reap.sdk.v0.4.21`.
- Updated IBC-GO dependency to version `3.2.0-reap.ibc.v0.5.22`.
 
